### PR TITLE
Fixed Deleting Name Crashing App

### DIFF
--- a/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
+++ b/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
@@ -10,7 +10,7 @@ class CustomAdapter(private val names: List<String>, private val context: Contex
 
     // How many items are in the collection
     override fun getCount(): Int {
-        return 5
+        return names.size
     }
 
     // Fetch an item from the collection


### PR DESCRIPTION
Fixed the first bug that crashes the app when you delete a name, getCount() had to be changed